### PR TITLE
Added minio automated setup (#12)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
+boto3
 requests
+botocore
+minio
 PyYAML

--- a/sto2/minio-config/buckets.py
+++ b/sto2/minio-config/buckets.py
@@ -1,0 +1,18 @@
+from s3 import S3
+import policies
+import json
+
+
+def create(s3: S3, buckets: list) -> None:
+    for bucket in buckets:
+        if not s3.bucket_exists(bucket['name']):
+            s3.make_bucket(bucket['name'])
+
+        if bucket['policy'] == "download":
+            policy = policies.Download(bucket=bucket['name']).get()
+        elif bucket['policy'] == "public":
+            policy = policies.Public(bucket=bucket['name']).get()
+        elif bucket['policy'] == "private":
+            policy = policies.Private(bucket=bucket['name']).get()
+
+        s3.set_bucket_policy(bucket['name'], json.dumps(policy))

--- a/sto2/minio-config/config.yml
+++ b/sto2/minio-config/config.yml
@@ -1,0 +1,33 @@
+---
+# minio s3 url and credentials.
+s3:
+  endpoint: minio.services.osism.tech
+  access_key: superuser
+  secret_key: somesecuresecret
+
+# this variable is unsed and rather for documentation of possible bucket policies
+bucket_policies:
+  - download # anonymous download possible
+  - public # anonymous upload, download and delete possible
+  - private # no unauthorized access possible
+
+# this variable is unsed and rather for documentation of possible user policies
+user_policies:
+  - readonly # user can only read
+  - readwrite # user can read, write (also delete of course)
+  - writeonly # user can only write, not read
+
+# list of buckets (does not delete buckets)
+buckets:
+  - name: public-images
+    policy: download
+  - name: secret-development-bucket
+    policy: private
+
+# list of users with policies (does not delete users)
+users:
+  - name: foo # needs to be at least 3 digits
+    secret: barbaz09 # needs to be at least 8 digits
+    buckets:
+      - name: public-images
+        policy: writeonly

--- a/sto2/minio-config/main.py
+++ b/sto2/minio-config/main.py
@@ -1,0 +1,59 @@
+import yaml
+import buckets
+import users
+import subprocess
+from s3 import S3, S3Admin
+
+
+def main(s3: S3, config: dict) -> None:
+    buckets.create(s3=s3, buckets=config['buckets'])
+
+
+def admin(s3admin: S3Admin, config: dict) -> None:
+    users.create(s3admin=s3admin, users=config['users'])
+
+
+if __name__ == "__main__":
+    with open("config.yml", "r") as stream:
+        try:
+            config = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+    s3 = S3(
+        endpoint=config['s3']['endpoint'],
+        access_key=config['s3']['secret_key'],
+        secret_key=config['s3']['access_key']
+    )
+
+    target = "mcconfig"
+    subprocess.run(
+        [
+            "mc",
+            "--json",
+            "alias",
+            "set",
+            target,
+            f"https://{config['s3']['endpoint']}",
+            config['s3']['secret_key'],
+            config['s3']['access_key']
+        ],
+        text=True,
+        check=True,
+        timeout=None,
+        env=None,
+        capture_output=True
+    )
+    s3admin = S3Admin(target=target)
+
+    main(s3, config)
+    admin(s3admin, config)
+
+    subprocess.run(
+        ["mc", "--json", "alias", "rm", target],
+        text=True,
+        check=True,
+        timeout=None,
+        env=None,
+        capture_output=True
+    )

--- a/sto2/minio-config/policies.py
+++ b/sto2/minio-config/policies.py
@@ -1,0 +1,105 @@
+class BucketPolicy:
+    bucket: str
+
+    def __init__(self, bucket: str) -> None:
+        self.bucket = bucket
+
+
+class Download(BucketPolicy):
+    def get(self) -> dict:
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": "*"},
+                    "Action": ["s3:GetBucketLocation", "s3:ListBucket"],
+                    "Resource": f"arn:aws:s3:::{self.bucket}",
+                },
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": "*"},
+                    "Action": "s3:GetObject",
+                    "Resource": f"arn:aws:s3:::{self.bucket}/*",
+                },
+            ],
+        }
+        return policy
+
+
+class Public(BucketPolicy):
+    def get(self) -> dict:
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": "*"},
+                    "Action": [
+                        "s3:GetBucketLocation",
+                        "s3:ListBucket",
+                        "s3:ListBucketMultipartUploads",
+                    ],
+                    "Resource": f"arn:aws:s3:::{self.bucket}",
+                },
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": "*"},
+                    "Action": [
+                        "s3:GetObject",
+                        "s3:PutObject",
+                        "s3:DeleteObject",
+                        "s3:ListMultipartUploadParts",
+                        "s3:AbortMultipartUpload",
+                    ],
+                    "Resource": f"arn:aws:s3:::{self.bucket}/*",
+                },
+            ],
+        }
+        return policy
+
+
+class Private(BucketPolicy):
+    def get(self) -> dict:
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [],
+        }
+        return policy
+
+
+class UserPolicy:
+    buckets: list
+    user: str
+
+    def __init__(self, buckets: list, user: str) -> None:
+        self.buckets = buckets
+        self.user = user
+
+    def get(self) -> dict:
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": []
+        }
+
+        for bucket in self.buckets:
+            entry = {
+                "Effect": "Allow",
+                "Action": [],
+                "Resource": [
+                    f"arn:aws:s3:::{bucket['name']}/*",
+                ]
+            }
+            if bucket['policy'] == "readonly":
+                entry['Action'].append("s3:GetBucketLocation")
+                entry['Action'].append("s3:GetObject")
+
+            if bucket['policy'] == "readwrite":
+                entry['Action'].append("s3:*")
+
+            if bucket['policy'] == "writeonly":
+                entry['Action'].append("s3:PutObject")
+
+            policy['Statement'].append(entry)
+
+        return policy

--- a/sto2/minio-config/s3.py
+++ b/sto2/minio-config/s3.py
@@ -1,0 +1,9 @@
+from minio import Minio, MinioAdmin
+
+
+class S3(Minio):
+    pass
+
+
+class S3Admin(MinioAdmin):
+    pass

--- a/sto2/minio-config/users.py
+++ b/sto2/minio-config/users.py
@@ -1,0 +1,19 @@
+from s3 import S3Admin
+from policies import UserPolicy
+import json
+import uuid
+import os
+
+
+def create(s3admin: S3Admin, users: list) -> None:
+    for user in users:
+        s3admin.user_add(user['name'], user['secret'])
+
+        # Set policies
+        policy = UserPolicy(buckets=user['buckets'], user=user['name'])
+        file = f"/tmp/{uuid.uuid1()}.json"
+        with open(file, 'w') as f:
+            json.dump(policy.get(), f)
+        s3admin.policy_add(user['name'], file)
+        os.remove(file)
+        s3admin.policy_set(user['name'], user['name'])


### PR DESCRIPTION
Closes #12.

Added automation script to configure minio.

Capable of adding buckets, accounts and policies.
Not capable of deleting buckets, accounts or policies.
Though, changing the access rights of a user will result in deleting old policies for this user.

Signed-off-by: Tim Beermann <beermann@osism.tech>
