### PR TITLE
added pulp service

### DIFF
--- a/sto1/pulp/README.md
+++ b/sto1/pulp/README.md
@@ -1,0 +1,86 @@
+# Pulp
+
+Pulp is a platform for managing repositories of content, such as software packages, and pushing that content out to large numbers of consumers. (taken from <https://pypi.org/project/pulpcore/>)
+
+We use pulp as a mirror for all packages osism requires. We do not use the pull-trough cache feature as it only caches the versions that where once ordered
+from this pulp installation and not other ones. Therefore we mirror all.
+
+## Setup the mirrors
+
+In case of a loss setup the mirrors like this.
+Syncing needs to happen regularly - we still need to find a solution to this.
+**WARNING** please do not use your local machine to execute the commands below.
+Rather use a VM with a screen session so the client does not disconnect.
+
+- Ansible
+  
+  Pull-through cache is not possible yet, so we need to mirror only special namespaces. No auto-publication.
+
+  ```sh
+  pulp ansible repository create --name "ansible-mirror"
+
+  pulp ansible remote -t "role" create --name "ansible-roles" --url "https://galaxy.ansible.com/api/v1/roles/?namespace__name=elastic"
+  pulp ansible remote -t "collection" create --name "ansible-collections" --url "https://galaxy.ansible.com/" --requirements "collections:\n  - osism.commons"
+
+  pulp ansible repository sync --name "ansible-mirror" --remote "role:ansible-roles"
+  pulp ansible repository sync --name "ansible-mirror" --remote "collection:ansible-collections"
+
+  pulp ansible distribution create --name "ansible-mirror-latest" --base-path "ansible-mirror" --repository "ansible-mirror"
+  ```
+
+- Containers
+  
+  Pull-through cache is not possible yet, so we need to mirror only special namespaces. No auto-publication.
+
+  ```sh
+  pulp container repository create --name "container-mirror"
+  pulp container remote create --name "container-mirror" --url "https://registry-1.docker.io" --upstream-name "library/hello-world"
+  pulp container repository sync --name "container-mirror" --remote "container-mirror"
+  pulp container distribution create --name "container-mirror-latest" --base-path "container-mirror" --repository "container-mirror"
+  ```
+
+- Debian Packages
+
+  Pull-through cache is available. No auto-publication.
+
+  ```sh
+  pulp deb repository create --name "deb-mirror"
+  pulp deb remote create --name "deb-mirror" --url http://ftp2.de.debian.org/debian/ --distribution bullseye --architecture amd64 --architecture arm64
+  pulp deb repository sync --name "deb-mirror" --mirror --remote "deb-mirror"
+  pulp deb distribution create --name "deb-mirror-latest" --base-path "deb-mirror" --repository "deb-mirror"
+  pulp deb publication create --repository "deb-mirror" --structured True
+  ```
+
+- PyPI
+
+  Pull-through cache is available. Auto-publication active.
+
+  ```sh
+  pulp python repository create --name "pypi-mirror" --autopublish
+  pulp python remote create --name "pypi-mirror" --url https://pypi.org/ --includes '["shelf-reader", "pip-tools>=1.12,<=2.0"]' --excludes '["django~=1.0", "scipy"]'
+  pulp python repository sync --name "pypi-mirror" --remote "pypi-mirror"
+  pulp python distribution create --name "pypi-mirror-latest" --base-path "pypi-mirror" --repository "pypi-mirror" --remote "pypi-mirror"
+  ```
+
+## Keep mirrors updated
+
+If a mirror has no auto-publish feature, you have to do the following things periodically (maybe via cron job?):
+
+- (...) repository sync (...)
+- (...) distribution sync (...)
+- (...) publication sync (...) # if required
+
+For a simple mirror of Debian repos it might be better to use verbatim publication instead of default APT publisher. This will mirror the upstream mirror exactly including signatures and it is much more efficient than APT publisher. Though, there is (currently) a bug with download policy streamed. Download policy immediate works fine.
+
+If you have auto-publish active, you just have to run the sync periodically.
+
+## Current mirror-sizes
+
+Date: 2022-06-17
+
+- Ansible (?GB)
+- Containers (?GB)
+- Debian (1091GB)
+  - amd64 (612GB)
+  - arm64 (479GB)
+- PyPI (11700GB)

--- a/sto1/pulp/notes.md
+++ b/sto1/pulp/notes.md
@@ -1,0 +1,105 @@
+# Pulp how to
+
+## preparation
+
+```sh
+sudo apt update
+sudo apt -y install tmux tree htop screen docker.io
+sudo usermod -a -G docker ubuntu
+sudo mkdir -p /usr/local/lib/docker/cli-plugins
+sudo curl -SL https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+sudo reboot
+
+## confiugure repo
+
+```sh
+git clone https://github.com/pulp/pulp-operator.git
+cd pulp-operator/containers
+ln -s podman-compose.yml docker-compose.yml
+```
+
+Change the port of the pulp-web from 8080 to 80.
+
+```sh
+sed -i 's/      \- \"8080\:8080\"/      \- \"80\:8080\"/g' docker-compose.yml
+```
+
+File *compose/settings.py*
+
+```py
+SECRET_KEY = "aabbcc"
+#CONTENT_ORIGIN = "http://localhost:24816"
+CONTENT_ORIGIN = "http://<public_ip_without_port>"
+DATABASES = {"default": {"HOST": "postgres", "ENGINE": "django.db.backends.postgresql", "NAME": "pulp", "USER": "pulp", "PASSWORD": "password", "PORT": "5432", "CONN_MAX_AGE": 0, "OPTIONS": {"sslmode": "prefer"}}}
+REDIS_HOST = "redis"
+REDIS_PORT = 6379
+REDIS_PASSWORD = ""
+#ANSIBLE_API_HOSTNAME = "http://localhost:24817"
+ANSIBLE_API_HOSTNAME = "http://pulp_api:24817"
+TOKEN_SERVER = "localhost:24817/token/"
+#TOKEN_AUTH_DISABLED = False
+TOKEN_AUTH_DISABLED = True
+TOKEN_SIGNATURE_ALGORITHM = "ES256"
+PUBLIC_KEY_PATH = "/etc/pulp/keys/container_auth_public_key.pem"
+PRIVATE_KEY_PATH = "/etc/pulp/keys/container_auth_private_key.pem"
+```
+
+File *compose/nginx/nginx.conf*
+
+```ini
+    (...)
+
+    upstream pulp-content {
+        #server localhost:24816;
+        server pulp-content:24816;
+    }
+
+    upstream pulp-api {
+        #server localhost:24817;
+        server pulp-api:24817;
+    }
+
+    (...)
+```
+
+## How to add a remote etc
+
+For .deb packages (bug opened <https://github.com/pulp/pulp_deb/issues/531>)
+
+```sh
+export name=test01
+pulp deb repository create --name "${name}"
+pulp deb remote create --name "${name}" --url http://nginx.org/packages/debian --distribution buster
+pulp deb repository sync --name "${name}" --mirror --remote "${name}"
+pulp deb distribution create --name "${name}" --base-path "${name}" --repository "${name}"
+pulp deb publication create --repository "${name}" --simple True
+#pulp deb publication create --repository "${name}" --structured True # is required for some reason before changing it to simple to get things working
+```
+
+For .rpm packages
+
+```sh
+export name=test02
+pulp rpm repository create --name "${name}"
+#pulp rpm remote create --name "${name}" --url https://download.ceph.com/rpm-pacific/el8/x86_64/
+pulp rpm remote create --name "${name}" --url https://nginx.org/packages/rhel/9/x86_64/
+pulp rpm repository sync --name "${name}" --mirror --remote "${name}" # full mirror
+#pulp rpm repository sync --name "${name}" --no-mirror --remote "${name}" # only cache
+pulp rpm distribution create --name "${name}" --base-path "${name}" --repository "${name}"
+pulp rpm publication create --repository "${name}"
+```
+
+## Starting / Stopping
+
+```sh
+docker compose up -d
+docker logs -f containers-pulp_api-1
+# wait till all migrations are done you might find workers dying,
+# especially when working on tasks with broken repo urls.
+# Most commonly this can be identified by the worker-logs stating
+# an error with the tmp directory.
+# You just have to restart the workers than (maybe even multiple
+# times). Not a nice, but working solution
+docker compose down -v
+```


### PR DESCRIPTION
WIP: Adding pulp as a mirror service for apt packages, pip packages and container images.
Closes osism/issues#187
Clsoes osism/issues#88

Signed-off-by: Tim Beermann <beermann@osism.tech>
